### PR TITLE
Mark OperatingSystemApp as End of Life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
OperatingSystemApp is no longer maintained and uses old runtime. So, mark it as End of Life.

Fixes: https://github.com/flathub/com.hack_computer.OperatingSystemApp/issues/5